### PR TITLE
过滤隐藏当type为library_content时的课程block

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/BlockType.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/BlockType.java
@@ -24,6 +24,7 @@ public enum  BlockType {
     HTML{ @Override public boolean isContainer() {return false;} },
     PROBLEM{ @Override public boolean isContainer() {return false;} },
     DISCUSSION{ @Override public boolean isContainer() {return false;} },
+    LIBRARY_CONTENT{ @Override public boolean isContainer() {return false;} },
     OTHERS{ @Override public boolean isContainer() {return false;} };
 
     abstract boolean isContainer();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
@@ -262,10 +262,16 @@ public class CourseOutlineAdapter extends BaseAdapter {
                         if (isVideoMode && child.getVideos().size() == 0)
                             continue;
                         SectionRow row = new SectionRow(SectionRow.ITEM, false, child);
+                        if (row.component.getType() == BlockType.LIBRARY_CONTENT){
+                            continue;
+                        }
                         adapterData.add(row);
                     }
                 } else {
                     SectionRow row = new SectionRow(SectionRow.ITEM, true, comp);
+                    if (row.component.getType() == BlockType.LIBRARY_CONTENT){
+                        continue;
+                    }
                     adapterData.add(row);
                 }
             }


### PR DESCRIPTION
解决无法在移动端打开type为library_content的课程组件block